### PR TITLE
fix: globIgnorePaths for content above relative path

### DIFF
--- a/rojo-test/build-test-snapshots/end_to_end__tests__build__ignore_glob_outer.snap
+++ b/rojo-test/build-test-snapshots/end_to_end__tests__build__ignore_glob_outer.snap
@@ -1,0 +1,17 @@
+---
+source: tests/tests/build.rs
+expression: contents
+---
+<roblox version="4">
+  <Item class="Folder" referent="0">
+    <Properties>
+      <string name="Name">ignore_glob_outer</string>
+    </Properties>
+    <Item class="ModuleScript" referent="1">
+      <Properties>
+        <string name="Name">include</string>
+        <string name="Source">-- This file should be included.</string>
+      </Properties>
+    </Item>
+  </Item>
+</roblox>

--- a/rojo-test/build-tests/ignore_glob_outer/README.md
+++ b/rojo-test/build-tests/ignore_glob_outer/README.md
@@ -1,0 +1,2 @@
+# ignore_glob_outer
+Tests that glob ignores above their current directory.

--- a/rojo-test/build-tests/ignore_glob_outer/default.project.json
+++ b/rojo-test/build-tests/ignore_glob_outer/default.project.json
@@ -1,0 +1,6 @@
+{
+  "name": "ignore_glob_outer",
+  "tree": {
+    "$path": "project"
+  }
+}

--- a/rojo-test/build-tests/ignore_glob_outer/outer/exclude.spec.lua
+++ b/rojo-test/build-tests/ignore_glob_outer/outer/exclude.spec.lua
@@ -1,0 +1,1 @@
+-- This file should not be included.

--- a/rojo-test/build-tests/ignore_glob_outer/outer/include.lua
+++ b/rojo-test/build-tests/ignore_glob_outer/outer/include.lua
@@ -1,0 +1,1 @@
+-- This file should be included.

--- a/rojo-test/build-tests/ignore_glob_outer/project/default.project.json
+++ b/rojo-test/build-tests/ignore_glob_outer/project/default.project.json
@@ -1,0 +1,9 @@
+{
+  "name": "project",
+  "tree": {
+    "$path": "../outer"
+  },
+  "globIgnorePaths": [
+    "**/*.spec.lua"
+  ]
+}

--- a/src/snapshot/metadata.rs
+++ b/src/snapshot/metadata.rs
@@ -229,10 +229,20 @@ impl PathIgnoreRule {
     pub fn passes<P: AsRef<Path>>(&self, path: P) -> bool {
         let path = path.as_ref();
 
-        match path.strip_prefix(&self.base_path) {
-            Ok(suffix) => !self.glob.is_match(suffix),
-            Err(_) => true,
-        }
+        let suffix = match path.strip_prefix(&self.base_path) {
+            Ok(suffix) => suffix.to_path_buf(),
+            Err(_) => {
+                // When paths are normalized, the target may be outside the
+                // base_path (e.g. a sibling directory via `../`). Compute the
+                // relative path so the glob can still match.
+                match pathdiff::diff_paths(path, &self.base_path) {
+                    Some(relative) => relative,
+                    None => return true,
+                }
+            }
+        };
+
+        !self.glob.is_match(suffix)
     }
 }
 

--- a/tests/tests/build.rs
+++ b/tests/tests/build.rs
@@ -32,6 +32,7 @@ gen_build_tests! {
     gitkeep,
     ignore_glob_inner,
     ignore_glob_nested,
+    ignore_glob_outer,
     ignore_glob_spec,
     infer_service_name,
     infer_starter_player,


### PR DESCRIPTION
I had an issue similar to yours at #907 for your fork.
Looks like it's already fixed on the main rojo repo.

Slight note, I did use Claude opus 4.6 for the issue fix I was having.
I don't know rust that well but it's just 10 lines at snapshot/metadata.
The test I made manually passes and it works for my setup.

[#907]: https://github.com/rojo-rbx/rojo/issues/907

<details>
<summary>Images</summary>
Project files I have:<br/>
<img alt="image" src="https://github.com/user-attachments/assets/4d93172a-1350-4658-b9b2-d53e985f249a" />
<img alt="image" src="https://github.com/user-attachments/assets/8746e0ef-59e5-4215-a78e-146b6827e120" />
<img alt="image" src="https://github.com/user-attachments/assets/52aefcd4-4ab8-4212-9e56-fc38ec106a05" />
<br/>Before & After:<br/>
<img alt="image" src="https://github.com/user-attachments/assets/540e4168-d902-456e-9ef5-a1ccfef7bd4c" />
<img alt="image" src="https://github.com/user-attachments/assets/ff9a139b-1c3e-4ee8-b20e-b8569cdd6a4d" />
</details>